### PR TITLE
Prevent output stream from hanging

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,7 @@ async function getResponseEntity(ctx, sizelimit) {
     if (body instanceof Stream) {
         if (!("path" in body)) {
             var tmpstream = new Stream.Transform({
+                writableHighWaterMark: sizelimit,
                 transform(chunk, encoding, callback) {
                     // console.log(chunk.toString(), encoding);
                     callback(null, chunk);

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -30,6 +30,28 @@ describe("when body is a stream without a .path smaller than sizelimit", functio
         });
         response.expect("ETag", /.+/).end(done);
     });
+
+    it("should not cause the response stream to hang", function (done) {
+        const app = new Koa()
+            .use(etag({ sizelimit: 100000000 }))
+            .use(function (ctx, next) {
+                return next().then(function () {
+                    ctx.body = stream.Readable.from(
+                        (async function* () {
+                            yield Buffer.from("X".repeat(5000000));
+                        })()
+                    );
+                });
+            });
+
+        var response = request(app.listen()).get("/");
+        // console.log(response);
+        response.expect((r) => {
+            console.log(r.headers);
+            return r;
+        });
+        response.expect("ETag", /.+/).end(done);
+    });
 });
 describe("when body is a stream without a .path larger than sizelimit", function () {
     it("should not add an ETag", function (done) {


### PR DESCRIPTION
- (fix) ensure output stream doesn't hang while calculating etag

The issue is that the transform stream being used for the new output has a high water mark to limit the maximum amount of written data that can be buffered until drained. Because the etag code doesn't complete until we either finish reading the source stream or hit the size limit, we get into a situation where we hang indefinitely waiting for the transform stream to drain if we hit the default high water mark since nothing is reading the stream yet.

Setting the high water mark to the same thing as the size limit should make sure we are allowed to buffer enough to allow the etag logic to complete.